### PR TITLE
Feature/show only relevant nodes v2

### DIFF
--- a/src/app/actions/graph.ts
+++ b/src/app/actions/graph.ts
@@ -130,7 +130,6 @@ export const actions: any = {
         .sort((a: number, b: number) => a - b)
       const nextId = ids[ids.length - 1] + 1 || 1
       const currentDate = new Date().toString()
-      console.log('new node created')
       const nodeData: IGraphNodeData = {
         id: nextId,
         title: 'Note ' + nextId,

--- a/src/app/actions/graph.ts
+++ b/src/app/actions/graph.ts
@@ -100,6 +100,7 @@ export const actions: any = {
       lastModified: node.lastModified,
       tags: node.tags,
       type: node.type,
+      isExpanded: node.isExpanded,
     }
 
     graphCommandStream.next(new EditNodeMetadataCommand(node))
@@ -129,6 +130,7 @@ export const actions: any = {
         .sort((a: number, b: number) => a - b)
       const nextId = ids[ids.length - 1] + 1 || 1
       const currentDate = new Date().toString()
+      console.log('new node created')
       const nodeData: IGraphNodeData = {
         id: nextId,
         title: 'Note ' + nextId,
@@ -138,6 +140,7 @@ export const actions: any = {
         y: position.y,
         tags: [],
         type: undefined,
+        isExpanded: true,
       }
 
       // Set parent if specified

--- a/src/components/graph/graph-utils.test.ts
+++ b/src/components/graph/graph-utils.test.ts
@@ -61,6 +61,7 @@ describe('graphMetadataToList', () => {
       y: 0,
       tags: [],
       type: NoteDataType.TEXT,
+      isExpanded: true,
     },
     1: {
       id: 0,
@@ -71,6 +72,7 @@ describe('graphMetadataToList', () => {
       y: 0,
       tags: [],
       type: NoteDataType.TEXT,
+      isExpanded: true,
     },
     2: {
       id: 2,
@@ -81,6 +83,7 @@ describe('graphMetadataToList', () => {
       y: 0,
       tags: [],
       type: NoteDataType.TEXT,
+      isExpanded: true,
     },
   }
 
@@ -94,6 +97,7 @@ describe('graphMetadataToList', () => {
       y: 0,
       tags: [],
       type: NoteDataType.TEXT,
+      isExpanded: true,
     },
     {
       id: 0,
@@ -104,6 +108,7 @@ describe('graphMetadataToList', () => {
       y: 0,
       tags: [],
       type: NoteDataType.TEXT,
+      isExpanded: true,
     },
     {
       id: 2,
@@ -114,6 +119,7 @@ describe('graphMetadataToList', () => {
       y: 0,
       tags: [],
       type: NoteDataType.TEXT,
+      isExpanded: true,
     },
   ]
 

--- a/src/components/graph/graph.ts
+++ b/src/components/graph/graph.ts
@@ -356,13 +356,60 @@ export default class GraphComponent {
     return svg
   }
 
+  private _allParentsExpanded(id: number): boolean {
+    const parentId = this._graphData!.childParentIndex[id]
+    if (parentId === null) {
+      return true
+    } else if (this._graphData!.metadata[parentId].isExpanded) {
+      return this._allParentsExpanded(parentId)
+    }
+    return false
+  }
+
+  private _visibleNodeMetadata(): IGraphNodeData[] {
+    const subset: IGraphNodeData[] = []
+    for (const i of this._graphData!.metadataItems) {
+      if (this._allParentsExpanded(i.id)) {
+        subset.push(i)
+      }
+    }
+    return subset
+  }
+
+  private _visibleNodeLinkdata(): ILinkTuple[] {
+    const subset: ILinkTuple[] = []
+    for (const i of this._graphData!.linkData) {
+      if (this._allParentsExpanded(i.target)) {
+        subset.push(i)
+      }
+    }
+    return subset
+  }
+
+  private _onNodeExpandClick(d: IGraphNodeData): void {
+    d3.event.stopPropagation()
+
+    d.isExpanded = !d.isExpanded
+    this._graphData!.metadata[d.id].isExpanded = d.isExpanded
+
+    this._nodes
+        .filter((nd: IGraphNodeData) => nd.id === d.id)
+        .select('.node-expand-btn')
+        .text((nd: IGraphNodeData) => nd.isExpanded ? '-' : '+')
+
+    this._renderNodes()
+    this._renderLinks()
+  }
+
   private _renderNodes(): void {
     const existingNodes = this._gNodes.selectAll('.node')
+
+    const visibleNodes = this._visibleNodeMetadata()
 
     const newNodes = existingNodes
       // NOTE: Key-function provides D3 with information about which datum maps to which
       // element. This allows arrays in different orders to work as expected
-      .data(this._graphData!.metadataItems, (d: IGraphNodeData) => d.id)
+      .data(visibleNodes, (d: IGraphNodeData) => d.id)
       .enter()
       .append('g')
       .attr('class', 'node')
@@ -399,7 +446,7 @@ export default class GraphComponent {
       .attr('height', GraphComponent._NODE_HEIGHT)
       .text((d: IGraphNodeData) =>
         d.title.length > 17 ? d.title.substr(0, 17 - 3) + '...' : d.title)
-    
+
     // append the expand/collapse button
     newNodes
       .append('rect')
@@ -407,21 +454,23 @@ export default class GraphComponent {
       .attr('y', 5)
       .attr('width', 15)
       .attr('height', 15)
-      .attr('stroke-width', 1)
-      .attr('fill', '#ffffff')
-      .on('click', (d: IGraphNodeData) => d.isExpanded = !d.isExpanded)
+      .on('click', (d: IGraphNodeData) => this._onNodeExpandClick(d))
+      .on('dblclick', () => d3.event.stopPropagation())
     newNodes
       .append('text')
+      .attr('class', 'node-expand-btn')
       .attr('x', GraphComponent._NODE_WIDTH - 5 - 12)
       .attr('y', 18)
-      .attr('width', 15)
-      .attr('height', 15)
+      .attr('width', 20)
+      .attr('height', 20)
       .text((d: IGraphNodeData) => d.isExpanded ? '-' : '+')
+      .on('click', (d: IGraphNodeData) => this._onNodeExpandClick(d))
+      .on('dblclick', () => d3.event.stopPropagation())
 
     existingNodes
       // NOTE: Key-function provides D3 with information about which datum maps to which
       // element. This allows arrays in different orders to work as expected
-      .data(this._graphData!.metadataItems, (d: IGraphNodeData) => d.id)
+      .data(visibleNodes, (d: IGraphNodeData) => d.id)
       .exit()
       .remove()
 
@@ -447,10 +496,12 @@ export default class GraphComponent {
 
     const existingLinks = this._gLinks.selectAll('.link')
 
+    const visibleLinks = this._visibleNodeLinkdata()
+
     existingLinks
       // NOTE: Key-function provides D3 with information about which datum maps to which
       // element. This allows arrays in different orders to work as expected
-      .data(this._graphData!.linkData, (l: ILinkTuple) => l.id)
+      .data(visibleLinks, (l: ILinkTuple) => l.id)
       .enter()
       .append('line')
       .attr('class', 'link')
@@ -472,7 +523,7 @@ export default class GraphComponent {
     existingLinks
       // NOTE: Key-function provides D3 with information about which datum maps to which
       // element. This allows arrays in different orders to work as expected
-      .data(this._graphData!.linkData, (l: ILinkTuple) => l.id)
+      .data(visibleLinks, (l: ILinkTuple) => l.id)
       .exit()
       .remove()
 

--- a/src/components/graph/graph.ts
+++ b/src/components/graph/graph.ts
@@ -399,6 +399,24 @@ export default class GraphComponent {
       .attr('height', GraphComponent._NODE_HEIGHT)
       .text((d: IGraphNodeData) =>
         d.title.length > 17 ? d.title.substr(0, 17 - 3) + '...' : d.title)
+    
+    // append the expand/collapse button
+    newNodes
+      .append('rect')
+      .attr('x', GraphComponent._NODE_WIDTH - 5 - 15)
+      .attr('y', 5)
+      .attr('width', 15)
+      .attr('height', 15)
+      .attr('stroke-width', 1)
+      .attr('fill', '#ffffff')
+      .on('click', (d: IGraphNodeData) => d.isExpanded = !d.isExpanded)
+    newNodes
+      .append('text')
+      .attr('x', GraphComponent._NODE_WIDTH - 5 - 12)
+      .attr('y', 18)
+      .attr('width', 15)
+      .attr('height', 15)
+      .text((d: IGraphNodeData) => d.isExpanded ? '-' : '+')
 
     existingNodes
       // NOTE: Key-function provides D3 with information about which datum maps to which

--- a/src/lib/io/import/index.ts
+++ b/src/lib/io/import/index.ts
@@ -40,6 +40,7 @@ function createNodes(
         y: 100 * (children.length - 1),
         tags: [],
         type: NoteDataType.TEXT, // TODO Handle file type
+        isExpanded: true,
       }
       index[nextId] = []
       nextId++
@@ -53,6 +54,7 @@ function createNodes(
         y: 100 * (children.length - 1),
         tags: [],
         type: NoteDataType.TEXT, // TODO Handle file type
+        isExpanded: true,
       }
       const [nextNextId, subchildren] = createNodes(
         nextId + 1, index, metadata, f.tree, depth + 1)

--- a/src/lib/io/io.test.ts
+++ b/src/lib/io/io.test.ts
@@ -33,6 +33,7 @@ const mockMetadata: IGraphMetadata = {
     y: 12,
     tags: ['tagA'],
     type: NoteDataType.TEXT,
+    isExpanded: true,
   },
   2: {
     id: 2,
@@ -43,6 +44,7 @@ const mockMetadata: IGraphMetadata = {
     y: 12,
     tags: ['tagB'],
     type: NoteDataType.HANDWRITING,
+    isExpanded: true,
   },
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,7 @@ export interface IGraphNodeData {
   y: number
   tags: string[]
   type: undefined | NoteDataType
+  isExpanded: boolean
 }
 
 export interface IDimensions {


### PR DESCRIPTION
I had planned to essentially duplicate out _graphdata and then filter it down to only the parts that would be visible and modify this instead on subsequent expands/collapses however after a lot of experimenting I was unable to get my copy to work as the graphdata is not ready to be used until 3 renders have happened and I cannot perform a render with my visible graphdata subset. You'll also notice I call both render links and render nodes independantly. This is because the primary render function requires parameters to be called that I am unaware of so this is a sort of hack around that. 